### PR TITLE
Get rid of trackers

### DIFF
--- a/lib/manager.js
+++ b/lib/manager.js
@@ -73,9 +73,8 @@ E.default = assign({}, Luminati.default, {
     usage_stats: true,
 });
 const default_port = 22225;
-const PROXY_INTERNAL_BYPASS = qw`google.com luminati.io`;
-const PROXY_ONLY_BYPASS = qw`googleapis.com cdnjs.com gstatic.com google.co.*
-    googleusercontent.com google.* luminati.io hwcdn.net lumtest.com`;
+const PROXY_INTERNAL_BYPASS = qw`luminati.io`;
+const PROXY_ONLY_BYPASS = qw`cdnjs.com luminati.io hwcdn.net lumtest.com`;
 
 const load_json = (filename, optional, def)=>{
     if (optional && !file.exists(filename))


### PR DESCRIPTION
These whitelists cause Luminati to leak metadata to any site that uses a Google product including Google Analytics, hosting, etc.

If you google "What is my ip?" without these removed, Google will reveal your real identity. This is an operational security issue and needs to be fixed.