### PR TITLE
Allow using Proxy Manager in electron applications

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const Luminati = require('./lib/luminati.js');
 const version = require('./package.json').version;
 let is_electron = process.versions && !!process.versions.electron;
 
-if (!is_electron)
+if (!is_electron || process.env.LUMINATI_DISABLE_ELECTRON === 'true')
 {
     module.exports = {Luminati, Manager, version};
     return;


### PR DESCRIPTION
We want to use the Proxy Manager programmatically in our application but this clause causes it to use it for some other purpose. Having an extra check on an environment variable, you could disable this logic and use as if you're not in Electron.