### PR TITLE
use Node.js version 10 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image.
-FROM node:9.4.0
+FROM node:10
 
 RUN npm install -g npm@4.6.1
 


### PR DESCRIPTION
Fix #131 
since release 1.108.399 Luminati Proxy manager uses Node.js version 10.