### PR TITLE
SSL: set generated cert validity notBefore to one day earlier

### DIFF
--- a/lib/ssl.js
+++ b/lib/ssl.js
@@ -36,7 +36,7 @@ function gen_cert(name, alt_names){
     const cert = pki.createCertificate();
     cert.publicKey = pki.publicKeyFromPem(keys.publicKeyPem);
     cert.serialNumber = ''+Date.now();
-    cert.validity.notBefore = new Date();
+    cert.validity.notBefore = new Date(Date.now()-1*86400000);
     cert.validity.notAfter = new Date(Date.now()+1*365*86400000);
     cert.setSubject([{name: 'commonName', value: name}]);
     cert.setIssuer(pki.certificateFromPem(E.ca.cert).issuer.attributes);


### PR DESCRIPTION
Issue:

- Proxy Manager is setup on some remote server and access to proxy ports shared between several different users.
- MiTM aka SSL analyse is enabled for port.
- Sometimes ewly generated certificate might be generated at least few seconds in future for the user if their PC have not exactly right time. Or there is some weird time zone issues.

Solution:

- Setting notBefore time to one day in past helps to fix all kind of issues.

I using this patch for one of my clients who actively use Luminati. I understand you're unlikely to merge this, but please consider applying this fix on your upstream version.

Thanks!